### PR TITLE
Fix daysSince issue with DST changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.1] - 20 July 2020
+
+* Port daysSince DST fix
+
 ## [0.1.0] - 8 November 2019
 
 * Publish initial library.

--- a/lib/date.dart
+++ b/lib/date.dart
@@ -67,7 +67,7 @@ class LocalDate {
   /// Returns the number of days in between this date and the current date.
   /// This value will be positive if the date is in the past, and negative
   /// if this date is in the future.
-  int get daysSince => today.toDateTime().difference(toDateTime()).inDays;
+  int get daysSince => (today.toDateTime().difference(toDateTime()).inHours / 24).round();
 
   /// Returns the number of days in between the current date and this date.
   /// This value will be positive if the date is in the future, and negative

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: typed_date_time
 description: Adds additional types for Local and UTC Dates and DateTimes.
-version: 0.1.0
+version: 0.1.1
 author: Michael Schoonmaker <schoon@actionsprout.com>
 homepage: https://github.com/ActionSprout/dart-typed-date-times
 


### PR DESCRIPTION
This PR fixes a `daysSince` issue with DST changes. This is a port of PR#149 from rhododendron from before the library diverged.